### PR TITLE
return string instead of null

### DIFF
--- a/Entity/Category.php
+++ b/Entity/Category.php
@@ -106,7 +106,7 @@ abstract class Category
         $this->pages     = new ArrayCollection();
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -130,7 +130,7 @@ abstract class Category
         return $this;
     }
 
-    public function getSlug(): string
+    public function getSlug(): ?string
     {
         return $this->slug;
     }

--- a/Entity/Page.php
+++ b/Entity/Page.php
@@ -179,7 +179,7 @@ abstract class Page
         $this->children  = new ArrayCollection();
     }
 
-    public function getTitle(): string
+    public function getTitle(): ?string
     {
         return $this->title;
     }
@@ -191,7 +191,7 @@ abstract class Page
         return $this;
     }
 
-    public function getSlug(): string
+    public function getSlug(): ?string
     {
         return $this->slug;
     }


### PR DESCRIPTION
Error cause by EasyAdmin, see example:

```
Return value of Orbitale\Bundle\CmsBundle\Entity\Page::getSlug() must be of the type string, null returned
```

This commit will fix the error provided from easyAdmin